### PR TITLE
Load jsPDF only when needed

### DIFF
--- a/index.html
+++ b/index.html
@@ -251,7 +251,6 @@
     <div id="popover" class="hidden"></div>
 
     <!-- Scripts -->
-    <script src="web/jspdf.min.js"></script>
     <script src="web/features.js"></script>
     <script src="web/theme.js"></script>
     <script src="web/localization.js"></script>

--- a/sw.js
+++ b/sw.js
@@ -14,7 +14,6 @@ const STATIC_FILES = [
     '/web/contacts.js',
     '/web/animation.js',
     '/web/optimization.js',
-    '/web/jspdf.min.js',
     '/projects.json',
     '/manifest.json'
 ];

--- a/web/contacts.js
+++ b/web/contacts.js
@@ -16,44 +16,38 @@ function openRSS() {
     window.open("feed.html", "_blank");
 }
 
-function downloadResume() {
+async function downloadResume() {
     console.log('Starting PDF generation...');
-    
+
+    let jsPDF;
+    try {
+        ({ jsPDF } = await import('./jspdf.min.js'));
+        console.log('jsPDF library loaded');
+    } catch (error) {
+        console.error('jsPDF library not loaded', error);
+        alert('PDF library not loaded. Please refresh the page.');
+        return;
+    }
+
     // Get current language
     const currentLang = localStorage.getItem('preferredLanguage') || 'en';
-    
+
     // Get translations - ALWAYS use English for PDF to avoid encoding issues
     const translations = window.translations || {};
     const data = translations['en'] || {}; // Force English to avoid UTF-8 issues
-    
+
     if (!data) {
         console.error('No translation data available');
         alert('Translation data not available. Please refresh the page.');
         return;
     }
-    
-    // Check if jsPDF is loaded
-    if (!window.jspdf) {
-        console.error('jsPDF library not loaded');
-        alert('PDF library not loaded. Please refresh the page.');
-        return;
-    }
-    
+
     console.log('jsPDF library available and translation data loaded');
-    
+
     try {
-        // Create new PDF instance (local jsPDF library)
-        const { jsPDF } = window.jspdf;
-        
-        if (!jsPDF) {
-            console.error('jsPDF constructor not available');
-            alert('PDF constructor not available');
-            return;
-        }
-        
         console.log('Creating PDF instance...');
         const doc = new jsPDF();
-        
+
         // Set font to support better text rendering
         doc.setFont('helvetica');
         


### PR DESCRIPTION
## Summary
- Remove static jsPDF script from index and service worker
- Dynamically import jsPDF inside downloadResume

## Testing
- `node --check web/contacts.js`
- `node --check sw.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ee79013208330810a3d55816a360a