### PR TITLE
Add noscript warning for JavaScript requirement

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,6 +110,7 @@
     </script>
 </head>
 <body>
+  <noscript>Для корректной работы сайта требуется включить JavaScript.</noscript>
   <!-- Skip navigation for accessibility -->
   <a href="#main-content" class="skip-nav">Skip to main content</a>
   <header>


### PR DESCRIPTION
## Summary
- warn users that JavaScript must be enabled for the site to function

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ee96f44108330aff87b65f4f36008