### PR TITLE
Add scroll-to-top button

### DIFF
--- a/index.html
+++ b/index.html
@@ -212,6 +212,10 @@
     <!-- Popover for skill descriptions -->
     <div id="popover" class="hidden"></div>
 
+    <button id="scroll-top" class="scroll-top" aria-label="Scroll to top">
+        <i class="fas fa-arrow-up"></i>
+    </button>
+
     <!-- Scripts -->
     <script src="web/features.js"></script>
     <script src="web/theme.js"></script>

--- a/style.css
+++ b/style.css
@@ -1993,3 +1993,31 @@ footer::before {
         font-size: 13px;
     }
 }
+
+/* Scroll to top button */
+.scroll-top {
+    position: fixed;
+    bottom: 20px;
+    right: 20px;
+    width: 40px;
+    height: 40px;
+    border: none;
+    border-radius: 50%;
+    background: var(--accent-color);
+    color: #fff;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    box-shadow: var(--card-shadow);
+    z-index: 1000;
+    transition: background var(--transition-normal);
+}
+
+.scroll-top:hover {
+    background: var(--accent-color-dark);
+}
+
+.scroll-top.show {
+    display: flex;
+}

--- a/web/animation.js
+++ b/web/animation.js
@@ -139,6 +139,24 @@ function setupSmoothScrolling() {
     });
 }
 
+// Scroll-to-top button
+function setupScrollTopButton() {
+    const btn = document.getElementById('scroll-top');
+    if (!btn) return;
+
+    window.addEventListener('scroll', () => {
+        if (window.scrollY > 300) {
+            btn.classList.add('show');
+        } else {
+            btn.classList.remove('show');
+        }
+    });
+
+    btn.addEventListener('click', () => {
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+}
+
 // Highlight active navigation link based on scroll position
 function setupScrollSpy() {
     const sections = document.querySelectorAll('section');
@@ -175,6 +193,7 @@ document.addEventListener('DOMContentLoaded', () => {
     setupCounters();
     setupAnimatedBackground();
     setupSmoothScrolling();
+    setupScrollTopButton();
     setupScrollSpy();
     
     // Add nav-link active class for current section


### PR DESCRIPTION
## Summary
- add fixed scroll-top button with Font Awesome arrow
- style button and hide until scrolling past threshold
- implement JS to toggle button and smooth-scroll to page top

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f0427bfe88330b7739c4f44b01fa4