### PR TITLE
fix(blog): match lander's theme-toggle + lang-btn pill sizing

### DIFF
--- a/hugo/assets/css/site.css
+++ b/hugo/assets/css/site.css
@@ -128,3 +128,70 @@ body > footer    { flex-shrink: 0; }
         color: var(--text);
     }
 }
+
+/* ── Header controls: theme toggle + lang switcher ────────────────
+   Carry over the lander's pill/switch look so the right-side controls
+   render identically on the lander and the blog. Long-term these should
+   move into DS as proper components. */
+
+.theme-toggle {
+    position: relative;
+    inline-size: 44px;
+    block-size: 24px;
+    background: rgba(0, 0, 0, 0.12);
+    border-radius: 12px;
+    border: none;
+    cursor: pointer;
+    padding: 4px;
+    transition: all 0.3s ease;
+    margin-inline-start: 4px;
+}
+
+.theme-toggle::after {
+    content: '';
+    position: absolute;
+    inset-block-start: 4px;
+    inset-inline-start: 4px;
+    inline-size: 18px;
+    block-size: 18px;
+    background: white;
+    border-radius: 50%;
+    transition: all 0.3s ease;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+}
+
+[dark-mode] .theme-toggle::after {
+    inset-inline-start: calc(100% - 21px);
+    background: var(--text);
+}
+
+.theme-toggle:hover { transform: scale(1.05); }
+
+.lang-switcher { display: flex; gap: 4px; }
+
+.lang-btn {
+    text-decoration: none;
+    color: var(--text);
+    font-weight: 500;
+    padding: 6px 12px;
+    border-radius: 100px;
+    transition: all 0.2s ease;
+    display: block;
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    font-size: var(--text-lg);
+    line-height: 1;
+}
+
+@media (hover: hover) {
+    .lang-btn:hover { background: rgba(0, 0, 0, 0.06); color: var(--text); }
+}
+
+.lang-btn.active { background: rgba(0, 0, 0, 0.06); color: var(--text); }
+
+[dark-mode] .lang-btn:hover,
+[dark-mode] .lang-btn.active {
+    background: rgba(255, 255, 255, 0.1);
+    color: var(--text);
+}


### PR DESCRIPTION
## Problem

The right-side controls pill (theme toggle + language switcher) renders **differently** on the lander vs the blog.

| | Lander (`.header-controls`) | Blog (`.navbar-controls`) — before fix |
|---|---|---|
| Pill width × height | 216 × 44 | 174 × 50 |
| `.theme-toggle` | 44×24 **switch-track** with round thumb (iOS style) | 36×36 square button (DS default) |
| `.lang-btn` | 42×30 pill with rounded active background | 32×24 small text button |

## Root cause

The lander's `style.css` has hand-tuned rules for `.theme-toggle` (switch with `::after` thumb) and `.lang-btn` (rounded pill). DS doesn't have these — DS `.toggle` is a checkbox-style component, very different shape.

The blog only loads DS (no `style.css`), so it falls back to default button styles. Result: visual divergence.

## Fix

Carry the same `.theme-toggle` and `.lang-btn` rules from `style.css` into `hugo/assets/css/site.css` so the blog matches the lander pixel for pixel.

After:
- Pill: 216×44 (matches lander)
- `.theme-toggle`: 44×24 switch (matches lander)
- `.lang-btn`: 42×30 pill (matches lander)

## Why not extend DS instead

That's the long-term path — promote `.theme-toggle` (switch shape) and `.lang-btn` (pill with active state) into DS as proper components, then both sites consume from DS. For now this is the low-risk hotfix that closes the visible bug.

## Verification

```bash
HUGO_PARAMS_DSTAG=v1.1.0 bin/preview.sh
# Visit /
# Visit /articles/<any>
# Right-side pill should look identical (same width, same toggle shape, same flag pill sizes).
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
