### PR TITLE
fix(blog): mobile drawer for .navbar--pill on article pages

### DIFF
--- a/hugo/assets/css/site.css
+++ b/hugo/assets/css/site.css
@@ -195,3 +195,80 @@ body > footer    { flex-shrink: 0; }
     background: rgba(255, 255, 255, 0.1);
     color: var(--text);
 }
+
+/* ── Mobile: turn the pill nav into a slide-out drawer ──────────────
+   Mirrors the lander's `@media (max-width: 768px) { nav { ... } }`
+   behavior (which DS doesn't provide for .navbar--pill).
+   On wide viewports the pill stays as-is. */
+
+@media (max-width: 768px) {
+    .navbar--pill {
+        position: fixed;
+        inset-block-start: 0;
+        inset-inline-start: -100%;
+        inset-inline-end: auto;
+        margin: 0;
+        inline-size: 280px;
+        max-inline-size: 80vw;
+        block-size: 100vh;
+        border-radius: 0;
+        padding-block: 80px var(--s-6);
+        padding-inline: var(--s-4);
+        background: var(--surface);
+        border: none;
+        box-shadow: 2px 0 20px rgba(0, 0, 0, 0.1);
+        backdrop-filter: none;
+        -webkit-backdrop-filter: none;
+        transition: inset-inline-start 0.3s ease;
+        visibility: hidden;
+        z-index: 999;
+    }
+
+    .navbar--pill.active {
+        inset-inline-start: 0;
+        visibility: visible;
+    }
+
+    .navbar--pill ul {
+        flex-direction: column;
+        gap: 0;
+        inline-size: 100%;
+    }
+
+    .navbar--pill ul li {
+        inline-size: 100%;
+    }
+
+    .navbar--pill ul li a {
+        display: block;
+        padding: 12px 16px;
+        inline-size: 100%;
+        border-radius: 8px;
+        font-size: 1rem;
+    }
+
+    /* Hamburger floats top-left with its own pill background */
+    .hamburger {
+        position: fixed;
+        inset-block-start: 14px;
+        inset-inline-start: 14px;
+        z-index: 1001;
+        background: rgba(255, 255, 255, 0.85);
+        backdrop-filter: blur(12px);
+        -webkit-backdrop-filter: blur(12px);
+        border-radius: 12px;
+        padding: 8px;
+        box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
+    }
+
+    [dark-mode] .hamburger {
+        background: rgba(22, 27, 34, 0.85);
+    }
+
+    /* Controls pill: tighter padding on mobile so it doesn't overlap nav */
+    .navbar-controls {
+        inset-block-start: 10px;
+        inset-inline-end: 10px;
+        padding: 6px 10px;
+    }
+}


### PR DESCRIPTION
## Problem

On mobile (< 768px), the article page had two visual bugs:

1. **A non-functional "sidebar"** stayed visible on screen — actually the floating pill nav (`.navbar.navbar--pill`) was rendered as a horizontal pill at full content width (~445px), overflowing a 390px viewport.
2. **The pill nav covered/overlapped the language switcher** because both were `position: fixed` and the pill nav's right edge fell into the controls pill's area.

## Root cause

DS `.navbar--pill` has no mobile transform. On wide viewports it's a glassy floating pill — perfect. On narrow viewports it just stays a pill and overflows.

The lander solves this in its own `style.css` with:

```css
@media (max-width: 768px) {
    nav { position: fixed; left: -100%; width: 280px; height: 100vh; ... }
    nav.active { left: 0; ... }
}
```

…which converts every `<nav>` into a hamburger-driven slide-out drawer. The blog only loads DS + site.css, neither had this rule.

## Fix

Mirrors the lander's mobile drawer for `.navbar--pill`:

- `@media (max-width: 768px)`:
  - `.navbar--pill` becomes a 280px-wide, 100vh-tall drawer parked at `inset-inline-start: -100%`
  - `.navbar--pill.active` slides it in (animation.js already adds `.active` on hamburger click)
  - The inner `<ul>` becomes vertical, items get full-width pill buttons
  - `.hamburger` floats at `top: 14, left: 14` with its own pill background (blur + shadow)
  - `.navbar-controls` gets tighter padding so it doesn't crowd the hamburger

## Why this lives in site.css and not DS (for now)

The pill nav as floating pill is a DS component, but the mobile drawer transformation is a site-level decision — different sites might want a different mobile behavior (collapse to icons, hide entirely, etc.). Keeping the transform in `site.css` until we have a strong opinion that "drawer" is the right DS default.

## Note on PR sequencing

This is a clean-up PR: the same fix was committed to `fix/pill-controls` AFTER #27 was merged, so it got stranded on a closed branch. Cherry-picked here onto a fresh branch from `main`.

## Verification

Resize browser to 390x844 (or use DevTools mobile emulation), navigate to an article:
- Top-left: 36×32 hamburger button with backdrop
- Top-right: pill with 3 flags + theme toggle (no overlap)
- Click hamburger → drawer slides in from left with vertical menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)
