### PR TITLE
fix(lander): hide empty popover on initial page load

### DIFF
--- a/index.html
+++ b/index.html
@@ -479,8 +479,12 @@
         <i class="fas fa-arrow-up"></i>
     </button>
 
-    <!-- Popover for skill descriptions -->
-    <div id="popover" class="hidden"></div>
+    <!-- Popover for skill descriptions — hidden by default via the native
+         [hidden] attribute (the previous `class="hidden"` referenced a class
+         that wasn't defined anywhere, so the popover rendered empty at
+         top:0;left:0 until JS first ran hidePopover()). web/skills.js sets
+         inline display:block/none directly, which overrides [hidden]. -->
+    <div id="popover" hidden></div>
 
     <!-- Scripts -->
     <!-- jspdf.min.js loaded dynamically only when needed for resume download -->


### PR DESCRIPTION
## Summary

Phantom empty white card was rendering at the top-left of the lander on every fresh page load until the user hovered a skill-tag.

## Root cause

`<div id="popover" class="hidden">` referenced a `.hidden` class that wasn't defined anywhere in `style.css` (or any other stylesheet) — so the class was a no-op. Meanwhile `#popover` is styled with background, padding, shadow, etc. and `position: absolute` with no explicit `top`/`left`, so it landed at `0,0`.

The popover only became invisible after the first `hidePopover()` JS call (which sets inline `display: none`) — but that only fires after a `mouseleave` from a `.skill-tag`. Anyone who didn't hover a skill before scrolling saw a stuck empty box.

## Fix

Replace dead `class="hidden"` with the native HTML5 `[hidden]` boolean attribute. Browsers apply `display: none` automatically; the existing JS that sets inline `style.display = 'block'/'none'` overrides it cleanly when toggling visibility.

One-line behavioural fix, no JS or CSS changes needed.

## Notes

Surfaced during post-merge review of PR #29. Pushed to the same feature branch after merge, which stranded the commit — recreating on a fresh branch off `main` per repo workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
