### PR TITLE
fix(blog): emit og:image dimensions for Telegram/LinkedIn/Slack

### DIFF
--- a/hugo/layouts/partials/head.html
+++ b/hugo/layouts/partials/head.html
@@ -11,9 +11,21 @@
      overlays the title via images.Text. Per-tag accent colors live in
      hugo/data/tag_colors.json. Result is content-hashed by Hugo, so it only
      rebuilds when the inputs (title/tag/base/font) actually change. */}}
-{{- $coverURL := "" -}}
+{{/* Cover image dimensions also feed og:image:width/height — Telegram,
+     LinkedIn, and Slack often refuse to render the large image card when
+     these are absent. All branches below produce 1200×630 (the OG-spec
+     size); only override if the author supplies a page-bundle resource
+     with intrinsic dimensions. */}}
+{{- $coverURL    := "" -}}
+{{- $coverWidth  := 1200 -}}
+{{- $coverHeight := 630  -}}
 {{- if .Params.cover -}}
   {{- $coverURL = .Params.cover | absURL -}}
+  {{- with .Resources.GetMatch .Params.cover -}}
+    {{- $coverURL    = .RelPermalink -}}
+    {{- $coverWidth  = .Width -}}
+    {{- $coverHeight = .Height -}}
+  {{- end -}}
 {{- else if and .IsPage (eq .Section "articles") -}}
   {{- $base := resources.Get "images/og-base.png" -}}
   {{- $fontBold := resources.Get "fonts/Inter-Bold.ttf" -}}
@@ -120,7 +132,11 @@
 <meta property="og:description" content="{{ $description }}">
 <meta property="og:url"         content="{{ .Permalink }}">
 <meta property="og:locale"      content="en_US">
-<meta property="og:image"       content="{{ $coverURL }}">
+<meta property="og:image"        content="{{ $coverURL }}">
+<meta property="og:image:type"   content="image/png">
+<meta property="og:image:width"  content="{{ $coverWidth }}">
+<meta property="og:image:height" content="{{ $coverHeight }}">
+<meta property="og:image:alt"    content="{{ $title }}">
 
 {{/* Article-specific OG — surfaces dates/tags/author to social and to crawlers
      that prefer OG over JSON-LD (LinkedIn, Slack, some AI fetchers). */}}


### PR DESCRIPTION
## Problem

Telegram (and LinkedIn/Slack risk too) dropped the link-preview image even though the `og:image` URL returned 200 with a perfectly valid 1200×630 PNG. The preview showed only text — title, description, author byline — no card image.

Reproducible after PR #29 deploy: send any article URL to `@WebpageBot` → "updated successfully" → re-send in any chat → text-only card.

## Root cause

When the scraper sees `<meta og:image>` alone, with no `og:image:width`, `og:image:height`, or `og:image:type`, it has no way to validate whether the image is worth the bandwidth/render cost before fetching. Conservative scrapers (Telegram, LinkedIn) often skip the image rather than risk pulling a misshapen asset, and fall back to text-only.

Adding the explicit dimensions and type hints tells the scraper:
> "This is a 1200×630 PNG. You can commit to the large image card."

## Fix

Emit the full `og:image:*` set:

```html
<meta property="og:image"        content="…/og-base_hu_<hash>.png">
<meta property="og:image:type"   content="image/png">
<meta property="og:image:width"  content="1200">
<meta property="og:image:height" content="630">
<meta property="og:image:alt"    content="…page title…">
```

Defaults `1200×630` cover all three branches in the OG cascade (auto-generated, lander fallback `og-default.png`, and any future article cover that's also produced from the 1200×630 canvas).

For author-supplied `.Params.cover` that's a page-bundle resource, the template now pulls intrinsic `.Width`/`.Height` so a future portrait/landscape image doesn't ship the wrong dimensions to scrapers.

## Verification

After local build, the article emits:
```
<meta property="og:image" content="https://dzarlax.dev/images/og-base_hu_e2b37932a4db4a25.png">
<meta property="og:image:type" content="image/png">
<meta property="og:image:width" content="1200">
<meta property="og:image:height" content="630">
<meta property="og:image:alt" content="…">
```

## Post-merge checklist

1. Wait ~2 min after merge → GH Pages redeploys.
2. `@WebpageBot` → send URL → "Update with content" button (forces full refresh including image).
3. Verify image now renders in a fresh chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
