### PR TITLE
fix(lander): restore skill-tag popover, baseline hide via CSS

### DIFF
--- a/index.html
+++ b/index.html
@@ -479,12 +479,10 @@
         <i class="fas fa-arrow-up"></i>
     </button>
 
-    <!-- Popover for skill descriptions — hidden by default via the native
-         [hidden] attribute (the previous `class="hidden"` referenced a class
-         that wasn't defined anywhere, so the popover rendered empty at
-         top:0;left:0 until JS first ran hidePopover()). web/skills.js sets
-         inline display:block/none directly, which overrides [hidden]. -->
-    <div id="popover" hidden></div>
+    <!-- Popover for skill descriptions. Hidden by default via #popover CSS
+         baseline (`display: none`), shown by web/skills.js setting inline
+         `style.display = 'block'` on skill-tag mouseenter. -->
+    <div id="popover"></div>
 
     <!-- Scripts -->
     <!-- jspdf.min.js loaded dynamically only when needed for resume download -->

--- a/style.css
+++ b/style.css
@@ -650,6 +650,13 @@ section h2 {
 
 /* Popover */
 #popover {
+    /* Baseline hidden — web/skills.js toggles via inline `style.display`
+       (block/none), which overrides this rule via inline-style specificity.
+       Previously relied on a no-op `class="hidden"` then on the native
+       [hidden] attribute; both interacted poorly with the JS-driven flow.
+       A CSS baseline is the simplest contract: nothing leaks before JS
+       takes over, and the existing show/hide code keeps working unchanged. */
+    display: none;
     position: absolute;
     background-color: var(--bg-secondary);
     color: var(--text-primary);


### PR DESCRIPTION
## Regression from #30

PR #30 fixed the empty phantom popover at page-load by switching `class="hidden"` (a class that was never defined anywhere) to the native `[hidden]` attribute.

That fixed the phantom-card bug, but **broke skill-tag hover popovers on desktop**: hovering a Core Competency no longer surfaced its description. In theory, inline `style.display = 'block'` set by `web/skills.js` should override the `[hidden]` attribute's `display: none`. In practice the interaction proved unreliable — browsers can treat the attribute as a stronger presentational hint than a plain UA rule.

## Fix

Move the hidden-by-default state from HTML attribute to CSS baseline:

- `style.css` — add `display: none` as the first declaration in `#popover { … }`
- `index.html` — drop the attribute; popover is now just `<div id="popover"></div>`

Inline `style.display = 'block'/'none'` set by `showPopover`/`hidePopover` unambiguously overrides the stylesheet rule (inline-style specificity beats any selector). No JS change required.

## Why this is the right contract

- Stylesheet baseline: the popover renders nothing until JS takes over → no phantom card (PR #30's win is preserved).
- Inline style: JS controls visibility deterministically, no attribute interactions.
- One source of truth for default visibility — the `#popover` rule itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
