### PR TITLE
fix(cdn): swap design-system CDN from jsdelivr to statically.io

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -102,7 +102,9 @@ jobs:
           done
           # Pin lander to the resolved DS tag so the CDN URL in index.html
           # always matches the blog's CSS reference (closes Layer 1 drift).
-          sed -i "s|design-system@[^/\"]*|design-system@${{ steps.ds.outputs.tag }}|g" _dist/index.html
+          # We serve DS via cdn.statically.io (jsdelivr had a poisoned-cache
+          # incident on v1.2.0 — 404 cached at the edge after the tag race).
+          sed -i -E "s|cdn\.statically\.io/gh/dzarlax/design-system/[^/\"]*/dist|cdn.statically.io/gh/dzarlax/design-system/${{ steps.ds.outputs.tag }}/dist|g" _dist/index.html
 
           echo "── Final deploy tree ──"
           find _dist -maxdepth 2 -type f | sort | head -40

--- a/hugo/layouts/partials/head.html
+++ b/hugo/layouts/partials/head.html
@@ -1,8 +1,8 @@
 {{- $title       := cond .IsHome .Site.Title (printf "%s — %s" .Title .Site.Title) -}}
 {{- $description := or .Description .Summary .Site.Params.description -}}
 {{- $dsTag       := .Site.Params.dsTag | default "main" -}}
-{{- $dsCSS       := printf "https://cdn.jsdelivr.net/gh/dzarlax/design-system@%s/dist/dzarlax.css" $dsTag -}}
-{{- $dsJS        := printf "https://cdn.jsdelivr.net/gh/dzarlax/design-system@%s/dist/dzarlax.js"  $dsTag -}}
+{{- $dsCSS       := printf "https://cdn.statically.io/gh/dzarlax/design-system/%s/dist/dzarlax.css" $dsTag -}}
+{{- $dsJS        := printf "https://cdn.statically.io/gh/dzarlax/design-system/%s/dist/dzarlax.js"  $dsTag -}}
 {{/* Resolve OG image. Priority:
        1. .Params.cover — author-supplied (page-bundle resource or absolute URL)
        2. Auto-generated 1200×630 PNG with article title (only for blog posts)
@@ -160,8 +160,8 @@
 {{- end }}
 
 {{/* Performance hints */}}
-<link rel="preconnect"  href="https://cdn.jsdelivr.net" crossorigin>
-<link rel="dns-prefetch" href="https://cdn.jsdelivr.net">
+<link rel="preconnect"  href="https://cdn.statically.io" crossorigin>
+<link rel="dns-prefetch" href="https://cdn.statically.io">
 <link rel="preconnect"  href="https://cdnjs.cloudflare.com" crossorigin>
 <link rel="dns-prefetch" href="https://cdnjs.cloudflare.com">
 <link rel="dns-prefetch" href="https://www.googletagmanager.com">

--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
 
     <!-- Content Security Policy -->
     <meta http-equiv="Content-Security-Policy"
-        content="default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net; font-src 'self' https://cdnjs.cloudflare.com; img-src 'self' data: https://via.placeholder.com; connect-src 'self' https://www.google-analytics.com https://analytics.google.com;">
+        content="default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://cdn.statically.io; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.statically.io; font-src 'self' https://cdnjs.cloudflare.com; img-src 'self' data: https://via.placeholder.com; connect-src 'self' https://www.google-analytics.com https://analytics.google.com;">
 
     <!-- Open Graph Meta Tags -->
     <meta property="og:title" content="Dzarlax - Alexey Panfilov | Product Manager & Tech Enthusiast">
@@ -103,7 +103,7 @@
     </style>
 
     <!-- Styles: design system base + site-specific overrides -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/dzarlax/design-system@v1.1.0/dist/dzarlax.css">
+    <link rel="stylesheet" href="https://cdn.statically.io/gh/dzarlax/design-system/v1.2.1/dist/dzarlax.css">
     <link rel="stylesheet" href="style.css?v=20260414">
 
     <!-- Preload critical modules -->


### PR DESCRIPTION
## Why

dzarlax.dev was rendering `.theme-toggle` as an unstyled stub because jsdelivr cache-poisoned the v1.2.0 (and now v1.2.1) bundle — its first GitHub fetch raced the tag push and the 404 got pinned at both Cloudflare and Fastly edges. `purge.jsdelivr.net` reports success but subsequent fetches keep returning a literal `Failed to fetch dzarlax/design-system@1.2.0 from GitHub.` (56 bytes). Fresh edges with `x-cache: MISS` reproduce the same body, so jsdelivr's origin currently can't reach GitHub for this repo at those tags — even though `raw.githubusercontent.com/.../v1.2.1/dist/dzarlax.css` serves the full 63KB bundle.

## What

Swap the design-system CDN from `cdn.jsdelivr.net/gh/...@<tag>` to `cdn.statically.io/gh/.../<tag>` (different cache, same git-backed mirror, same per-tag pin model).

- `index.html`: stylesheet href + CSP allowlist (`cdn.statically.io` in style-src and script-src; `cdn.jsdelivr.net` removed)
- `hugo/layouts/partials/head.html`: `$dsCSS` / `$dsJS` printf templates + preconnect / dns-prefetch hints
- `.github/workflows/deploy.yml`: replace the jsdelivr `@<tag>` sed with a statically-style `/<tag>/dist` sed

Source pin bumped to `v1.2.1` (cosmetic — CI still resolves whichever tag `gh api repos/dzarlax/design-system/releases/latest` returns and substitutes via sed at deploy time).

Verified: `curl -s https://cdn.statically.io/gh/dzarlax/design-system/v1.2.1/dist/dzarlax.css | wc -c` → 63151 bytes, 9 `theme-toggle` matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
