### PR TITLE
fix(cdn): use statically.io's canonical @<tag> URL form

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -104,7 +104,7 @@ jobs:
           # always matches the blog's CSS reference (closes Layer 1 drift).
           # We serve DS via cdn.statically.io (jsdelivr had a poisoned-cache
           # incident on v1.2.0 — 404 cached at the edge after the tag race).
-          sed -i -E "s|cdn\.statically\.io/gh/dzarlax/design-system/[^/\"]*/dist|cdn.statically.io/gh/dzarlax/design-system/${{ steps.ds.outputs.tag }}/dist|g" _dist/index.html
+          sed -i -E "s|cdn\.statically\.io/gh/dzarlax/design-system@[^/\"]*|cdn.statically.io/gh/dzarlax/design-system@${{ steps.ds.outputs.tag }}|g" _dist/index.html
 
           echo "── Final deploy tree ──"
           find _dist -maxdepth 2 -type f | sort | head -40

--- a/hugo/layouts/partials/head.html
+++ b/hugo/layouts/partials/head.html
@@ -1,8 +1,8 @@
 {{- $title       := cond .IsHome .Site.Title (printf "%s — %s" .Title .Site.Title) -}}
 {{- $description := or .Description .Summary .Site.Params.description -}}
 {{- $dsTag       := .Site.Params.dsTag | default "main" -}}
-{{- $dsCSS       := printf "https://cdn.statically.io/gh/dzarlax/design-system/%s/dist/dzarlax.css" $dsTag -}}
-{{- $dsJS        := printf "https://cdn.statically.io/gh/dzarlax/design-system/%s/dist/dzarlax.js"  $dsTag -}}
+{{- $dsCSS       := printf "https://cdn.statically.io/gh/dzarlax/design-system@%s/dist/dzarlax.css" $dsTag -}}
+{{- $dsJS        := printf "https://cdn.statically.io/gh/dzarlax/design-system@%s/dist/dzarlax.js"  $dsTag -}}
 {{/* Resolve OG image. Priority:
        1. .Params.cover — author-supplied (page-bundle resource or absolute URL)
        2. Auto-generated 1200×630 PNG with article title (only for blog posts)

--- a/index.html
+++ b/index.html
@@ -103,7 +103,7 @@
     </style>
 
     <!-- Styles: design system base + site-specific overrides -->
-    <link rel="stylesheet" href="https://cdn.statically.io/gh/dzarlax/design-system/v1.2.1/dist/dzarlax.css">
+    <link rel="stylesheet" href="https://cdn.statically.io/gh/dzarlax/design-system@v1.2.1/dist/dzarlax.css">
     <link rel="stylesheet" href="style.css?v=20260414">
 
     <!-- Preload critical modules -->


### PR DESCRIPTION
statically.io 301-redirects /<tag>/ → http://...@<tag>/... (HTTP, not HTTPS — their bug). CSP blocks the HTTP downgrade, so all DS styles were silently disabled. Switch to the @<tag> form (no redirect, served over HTTPS directly). Verified curl: 200, 63151 bytes.