### PR TITLE
feat(blog): details shortcode for collapsible code blocks

### DIFF
--- a/hugo/assets/css/site.css
+++ b/hugo/assets/css/site.css
@@ -369,3 +369,36 @@ body > footer    { flex-shrink: 0; }
 .fn-popover > *:last-child { margin-block-end: 0; }
 .fn-popover p { margin-block: var(--s-2); }
 
+/* ── Code-fold (details shortcode) ──────────────────────────────────
+   Used by {{< details summary="..." >}}…{{< /details >}} — see
+   hugo/layouts/shortcodes/details.html. Wraps a long block (typically
+   a code listing) behind a native <details>/<summary> toggle so the
+   article body stays scannable.
+   ──────────────────────────────────────────────────────────────── */
+details.code-fold {
+    margin-block: var(--s-6);
+    border-inline-start: 3px solid var(--accent, currentColor);
+    padding-inline-start: var(--s-4);
+}
+details.code-fold > summary {
+    cursor: pointer;
+    font-size: 0.875rem;
+    color: var(--text);
+    opacity: 0.6;
+    padding-block: var(--s-2);
+    user-select: none;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    transition: opacity 0.15s ease;
+}
+details.code-fold > summary:hover,
+details.code-fold[open] > summary {
+    opacity: 1;
+}
+details.code-fold[open] > summary {
+    margin-block-end: var(--s-3);
+}
+details.code-fold > pre,
+details.code-fold > .highlight {
+    margin-block-start: 0;
+}
+

--- a/hugo/layouts/shortcodes/details.html
+++ b/hugo/layouts/shortcodes/details.html
@@ -1,0 +1,16 @@
+{{- /* {{< details summary="..." >}}…{{< /details >}}
+
+  Renders a native HTML <details>/<summary> disclosure. The inner content
+  is re-parsed as markdown via `markdownify` so authors can keep using
+  fenced code blocks (Chroma-highlighted) and other markdown features
+  inside the fold. Use the angle-bracket form of the shortcode; the
+  template handles the markdown step.
+
+  Attribute:
+    summary — text shown on the always-visible summary row.
+              Defaults to "Show implementation" if omitted.
+*/ -}}
+<details class="code-fold">
+  <summary>{{ .Get "summary" | default "Show implementation" | markdownify }}</summary>
+  {{ .Inner | markdownify }}
+</details>

--- a/hugo/layouts/shortcodes/details.html
+++ b/hugo/layouts/shortcodes/details.html
@@ -1,16 +1,18 @@
 {{- /* {{< details summary="..." >}}…{{< /details >}}
 
-  Renders a native HTML <details>/<summary> disclosure. The inner content
-  is re-parsed as markdown via `markdownify` so authors can keep using
-  fenced code blocks (Chroma-highlighted) and other markdown features
-  inside the fold. Use the angle-bracket form of the shortcode; the
-  template handles the markdown step.
+  Renders a native HTML <details>/<summary> disclosure. Inner content is
+  re-parsed as markdown via `.Page.RenderString` (not `markdownify`) so
+  it carries page context: page-bundle resource lookups, the
+  render-image hook, and other Page-bound machinery keep working inside
+  the fold. Use the angle-bracket form of the shortcode; the template
+  handles the markdown step.
 
   Attribute:
-    summary — text shown on the always-visible summary row.
-              Defaults to "Show implementation" if omitted.
+    summary — markdown text shown on the always-visible summary row.
+              Defaults to "Show implementation" if omitted. Inline
+              markdown (backticks, bold) is supported.
 */ -}}
 <details class="code-fold">
-  <summary>{{ .Get "summary" | default "Show implementation" | markdownify }}</summary>
-  {{ .Inner | markdownify }}
+  <summary>{{ .Page.RenderString (.Get "summary" | default "Show implementation") }}</summary>
+  {{ .Page.RenderString (dict "display" "block") .Inner }}
 </details>


### PR DESCRIPTION
## Summary

Adds a `{{< details summary="..." >}}…{{< /details >}}` shortcode for
wrapping long code listings (or any block) behind a native HTML
`<details>`/`<summary>` disclosure.

- `hugo/layouts/shortcodes/details.html` — 4-line template that emits
  `<details class="code-fold">` with the inner content re-parsed as
  markdown so fenced code blocks keep their Chroma syntax highlighting.
  The `summary` attribute is also passed through `markdownify`, so
  authors can write inline backticks (`` `ServerClient` `` →
  `<code>ServerClient</code>`).
- `hugo/assets/css/site.css` — `.code-fold` styles: muted monospace
  summary with a left accent rail, opens to full opacity. Flat
  selectors per the Hugo-minifier-safe rule already documented in
  CLAUDE.md.

## Why

Three already-written articles in the vault
(`part-5-energy-bank-problem`, `part-7-app-that-stopped-doing-the-math`,
`part-8-asking-before-telling`) use this shortcode to fold long Go and
Swift listings out of the main reading flow. Without the template the
shortcode silently emits nothing.

## Test plan

- [x] Local build against the real vault
  (`HUGO_BUILDDRAFTS=true HUGO_BUILDFUTURE=true hugo`): renders
  `<details class="code-fold"><summary>Show the <code>ServerClient</code> declaration (Swift, ~15 lines)</summary><div class="highlight">…<code class="language-swift">…</code></div></details>`.
- [x] `markdownify` keeps the inner fenced code block intact —
  Chroma classes (`chroma`, `language-swift`) are present inside the
  fold.
- [x] No regression on articles without the shortcode (the 2 published
  articles still render identically).
