### PR TITLE
fix(prose): keep article images proportional, never overflow column

### DIFF
--- a/hugo/assets/css/site.css
+++ b/hugo/assets/css/site.css
@@ -402,3 +402,47 @@ details.code-fold > .highlight {
     margin-block-start: 0;
 }
 
+
+/* ── Article images: proportional, never overflow column ───────────────
+ * render-image.html emits intrinsic width/height from page-bundle resources
+ * (good for CLS), but a 2640×590 screenshot would otherwise render at
+ * literal 2640px wide. Cap inline-size at the column and recover aspect
+ * ratio by overriding the height attribute back to auto.
+ * ──────────────────────────────────────────────────────────────────── */
+.prose img,
+.prose figure img {
+    max-inline-size: 100%;
+    block-size: auto;
+    display: block;
+    margin-inline: auto;
+    border-radius: 6px;
+}
+
+.prose figure {
+    margin-block: var(--s-8);
+    margin-inline: auto;
+    max-inline-size: 100%;
+}
+
+.prose figcaption {
+    text-align: center;
+    font-size: 0.9em;
+    color: var(--muted, var(--text));
+    opacity: 0.75;
+    margin-block-start: var(--s-3);
+    font-style: italic;
+    line-height: 1.4;
+}
+
+/* The article markdown uses `![alt](file.png)\n\n*caption*` pattern (plain
+ * italic paragraph after the image), not Markdown title-syntax that would
+ * trigger <figcaption>. Style that follow-up italic paragraph the same way
+ * a real figcaption would look, so both patterns read consistently. */
+.prose img + p > em:only-child,
+.prose p:has(> img) + p > em:only-child {
+    display: block;
+    text-align: center;
+    font-size: 0.9em;
+    opacity: 0.75;
+    line-height: 1.4;
+}


### PR DESCRIPTION
## Summary

- Add the missing `.prose img` rules: `max-inline-size: 100%` + `block-size: auto` so images cap at the article column and recover their aspect ratio (the render hook emits intrinsic `width`/`height` from page-bundle resources, which is good for CLS but locks the image at literal pixel width without `height: auto`).
- Style the article-side caption pattern (italic-only paragraph after an image) so `![alt](file)\n\n*caption*` reads consistently with markdown title-syntax `<figcaption>`.
- 6px radius on article images, centred block layout.

Symptom that prompted this: screenshots in the freshly-published Health Dashboard series (some 2640×590, 2500×360 aspect ratios) rendered visibly squashed at typical column widths.

## Test plan

- [ ] Local preview: `bin/preview.sh` and open `/articles/part-1-score-i-could-trust/` — `dashboard-hero.png` (2640×1200) should fill the column with correct aspect ratio.
- [ ] Open `/articles/part-3-wearables-lying-by-omission/` — `sleep-stages-five-bands.png` (2640×590) should render as a wide-and-short banner, not a stretched square.
- [ ] Open `/articles/part-7-app-that-stopped-doing-the-math/` — `methodology-badges.png` (2500×360) same check.
- [ ] Captions (italic paragraph after image) should appear centred and muted.
- [ ] No regression on the existing `from-karakeep-to-readeck` / `sleeping-terminal-1000-dollars` articles.