### PR TITLE
fix(theme): toggle stuck on system-dark devices (mobile)

### DIFF
--- a/hugo/assets/js/theme.js
+++ b/hugo/assets/js/theme.js
@@ -1,86 +1,89 @@
-// Theme handling with modern JavaScript
+// Theme handling — canonical two-attribute pattern that the
+// dzarlax/design-system bundle expects.
+//
+//   <html dark-mode>  — force dark (overrides system pref)
+//   <html light-mode> — force light (overrides system pref)
+//   <html> (no attr)  — follow `prefers-color-scheme`
+//
+// We always pick one of the two attributes (never "no attr") so that
+// DS's `@media (prefers-color-scheme: dark) :root:not([light-mode])`
+// fallback never silently overrides the user's manual choice on devices
+// whose system pref disagrees with that choice. The lander's style.css
+// only listens to `[dark-mode]` (no @media), so eager resolution is
+// required for the lander to track theme correctly anyway.
+//
+// Kept in sync with web/theme.js (lander copy).
 
-// Utility function to set theme
-function setTheme(theme) {
-    const themeToggle = document.querySelector('.theme-toggle');
-    if (!themeToggle) return;
-    
-    if (theme === 'dark') {
-        document.documentElement.setAttribute('dark-mode', '');
-        themeToggle.classList.add('dark');
-        localStorage.setItem('theme', 'dark');
-    } else {
-        document.documentElement.removeAttribute('dark-mode');
-        themeToggle.classList.remove('dark');
-        localStorage.setItem('theme', 'light');
-    }
-}
+(function () {
+    const ROOT = document.documentElement;
+    const STORAGE_KEY = 'theme';
+    const mqDark = window.matchMedia('(prefers-color-scheme: dark)');
 
-function initTheme() {
-    const themeToggle = document.querySelector('.theme-toggle');
-    if (!themeToggle) return;
-    
-    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-    const storedTheme = localStorage.getItem('theme');
-    
-    // Set initial theme based on stored preference or system preference
-    if (storedTheme === 'dark' || (!storedTheme && prefersDark)) {
-        setTheme('dark');
-    }
-
-    // Theme toggle handler with animation
-    themeToggle.addEventListener('click', function() {
-        const isDark = document.documentElement.hasAttribute('dark-mode');
-        
-        // Add transition class for smooth color changes
-        document.body.classList.add('theme-transition');
-        
-        const newTheme = isDark ? 'light' : 'dark';
-        setTheme(newTheme);
-        
-        // Remove transition class after animation completes
-        setTimeout(() => {
-            document.body.classList.remove('theme-transition');
-        }, 500);
-        
-        // Refresh animations for visible sections
-        refreshAnimations();
-    });
-
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
-        if (!localStorage.getItem('theme')) {
-            if (e.matches) {
-                document.documentElement.setAttribute('dark-mode', '');
-                themeToggle.classList.add('dark');
-            } else {
-                document.documentElement.removeAttribute('dark-mode');
-                themeToggle.classList.remove('dark');
-            }
+    function applyTheme(theme) {
+        if (theme === 'dark') {
+            ROOT.setAttribute('dark-mode', '');
+            ROOT.removeAttribute('light-mode');
+        } else {
+            ROOT.setAttribute('light-mode', '');
+            ROOT.removeAttribute('dark-mode');
         }
-    });
-}
-
-// Refresh animations for visible sections
-function refreshAnimations() {
-    // Reset and retrigger animations for visible sections
-    document.querySelectorAll('.reveal.active').forEach(el => {
-        el.classList.remove('active');
-        setTimeout(() => {
-            el.classList.add('active');
-        }, 50);
-    });
-}
-
-// Initialize theme when DOM is loaded
-document.addEventListener('DOMContentLoaded', initTheme);
-
-// Add CSS for theme transition
-const style = document.createElement('style');
-style.textContent = `
-    .theme-transition,
-    .theme-transition * {
-        transition: background-color 0.5s ease, color 0.5s ease, border-color 0.5s ease, box-shadow 0.5s ease !important;
+        const themeToggle = document.querySelector('.theme-toggle');
+        if (themeToggle) themeToggle.classList.toggle('dark', theme === 'dark');
     }
-`;
-document.head.appendChild(style);
+
+    function setTheme(theme, persist) {
+        applyTheme(theme);
+        if (persist) {
+            try { localStorage.setItem(STORAGE_KEY, theme); } catch (_) {}
+        }
+    }
+
+    function resolveInitial() {
+        let stored = null;
+        try { stored = localStorage.getItem(STORAGE_KEY); } catch (_) {}
+        if (stored === 'dark' || stored === 'light') return stored;
+        return mqDark.matches ? 'dark' : 'light';
+    }
+
+    function initTheme() {
+        const initial = resolveInitial();
+        applyTheme(initial);
+
+        const themeToggle = document.querySelector('.theme-toggle');
+        if (themeToggle) {
+            themeToggle.addEventListener('click', function () {
+                const isDark = ROOT.hasAttribute('dark-mode');
+                document.body.classList.add('theme-transition');
+                setTheme(isDark ? 'light' : 'dark', true);
+                setTimeout(() => document.body.classList.remove('theme-transition'), 500);
+                refreshAnimations();
+            });
+        }
+
+        mqDark.addEventListener('change', function (e) {
+            let stored = null;
+            try { stored = localStorage.getItem(STORAGE_KEY); } catch (_) {}
+            if (stored === 'dark' || stored === 'light') return;
+            applyTheme(e.matches ? 'dark' : 'light');
+        });
+    }
+
+    function refreshAnimations() {
+        document.querySelectorAll('.reveal.active').forEach(el => {
+            el.classList.remove('active');
+            setTimeout(() => el.classList.add('active'), 50);
+        });
+    }
+
+    document.addEventListener('DOMContentLoaded', initTheme);
+
+    const style = document.createElement('style');
+    style.textContent = `
+        .theme-transition,
+        .theme-transition * {
+            transition: background-color 0.5s ease, color 0.5s ease,
+                        border-color 0.5s ease, box-shadow 0.5s ease !important;
+        }
+    `;
+    document.head.appendChild(style);
+})();

--- a/hugo/layouts/partials/head.html
+++ b/hugo/layouts/partials/head.html
@@ -197,9 +197,9 @@
   (function () {
     try {
       var t = localStorage.getItem('theme');
-      if (t === 'dark' || (!t && matchMedia('(prefers-color-scheme: dark)').matches)) {
-        document.documentElement.setAttribute('data-theme', 'dark');
-      }
+      var dark = t === 'dark'
+        || (t !== 'light' && matchMedia('(prefers-color-scheme: dark)').matches);
+      document.documentElement.setAttribute(dark ? 'dark-mode' : 'light-mode', '');
       var lang = localStorage.getItem('preferredLanguage');
       if (lang && /^(en|ru|rs)$/.test(lang)) {
         // Only set data-lang for nav-bar/UI strings — DO NOT rewrite

--- a/index.html
+++ b/index.html
@@ -22,13 +22,17 @@
 
     <!-- Inline theme script to prevent flash of wrong theme -->
     <script>
-        (function() {
-            const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-            const storedTheme = localStorage.getItem('theme');
-
-            if (storedTheme === 'dark' || (!storedTheme && prefersDark)) {
-                document.documentElement.setAttribute('dark-mode', '');
-            }
+        (function () {
+            // Pre-paint theme bootstrap. Sets one of two attributes eagerly so
+            // DS's `@media (prefers-color-scheme: dark) :root:not([light-mode])`
+            // fallback can't override the user's manual choice on devices whose
+            // system pref disagrees. Canonical pattern, see web/theme.js.
+            try {
+                var stored = localStorage.getItem('theme');
+                var dark = stored === 'dark'
+                    || (stored !== 'light' && matchMedia('(prefers-color-scheme: dark)').matches);
+                document.documentElement.setAttribute(dark ? 'dark-mode' : 'light-mode', '');
+            } catch (_) {}
         })();
     </script>
 

--- a/web/theme.js
+++ b/web/theme.js
@@ -1,86 +1,94 @@
-// Theme handling with modern JavaScript
+// Theme handling — canonical two-attribute pattern that the
+// dzarlax/design-system bundle expects.
+//
+//   <html dark-mode>  — force dark (overrides system pref)
+//   <html light-mode> — force light (overrides system pref)
+//   <html> (no attr)  — follow `prefers-color-scheme`
+//
+// We always pick one of the two attributes (never "no attr") so that
+// DS's `@media (prefers-color-scheme: dark) :root:not([light-mode])`
+// fallback never silently overrides the user's manual choice on devices
+// whose system pref disagrees with that choice. The lander's style.css
+// only listens to `[dark-mode]` (no @media), so eager resolution is
+// required for the lander to track theme correctly anyway.
 
-// Utility function to set theme
-function setTheme(theme) {
-    const themeToggle = document.querySelector('.theme-toggle');
-    if (!themeToggle) return;
-    
-    if (theme === 'dark') {
-        document.documentElement.setAttribute('dark-mode', '');
-        themeToggle.classList.add('dark');
-        localStorage.setItem('theme', 'dark');
-    } else {
-        document.documentElement.removeAttribute('dark-mode');
-        themeToggle.classList.remove('dark');
-        localStorage.setItem('theme', 'light');
-    }
-}
+(function () {
+    const ROOT = document.documentElement;
+    const STORAGE_KEY = 'theme';
+    const mqDark = window.matchMedia('(prefers-color-scheme: dark)');
 
-function initTheme() {
-    const themeToggle = document.querySelector('.theme-toggle');
-    if (!themeToggle) return;
-    
-    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-    const storedTheme = localStorage.getItem('theme');
-    
-    // Set initial theme based on stored preference or system preference
-    if (storedTheme === 'dark' || (!storedTheme && prefersDark)) {
-        setTheme('dark');
-    }
-
-    // Theme toggle handler with animation
-    themeToggle.addEventListener('click', function() {
-        const isDark = document.documentElement.hasAttribute('dark-mode');
-        
-        // Add transition class for smooth color changes
-        document.body.classList.add('theme-transition');
-        
-        const newTheme = isDark ? 'light' : 'dark';
-        setTheme(newTheme);
-        
-        // Remove transition class after animation completes
-        setTimeout(() => {
-            document.body.classList.remove('theme-transition');
-        }, 500);
-        
-        // Refresh animations for visible sections
-        refreshAnimations();
-    });
-
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
-        if (!localStorage.getItem('theme')) {
-            if (e.matches) {
-                document.documentElement.setAttribute('dark-mode', '');
-                themeToggle.classList.add('dark');
-            } else {
-                document.documentElement.removeAttribute('dark-mode');
-                themeToggle.classList.remove('dark');
-            }
+    function applyTheme(theme) {
+        if (theme === 'dark') {
+            ROOT.setAttribute('dark-mode', '');
+            ROOT.removeAttribute('light-mode');
+        } else {
+            ROOT.setAttribute('light-mode', '');
+            ROOT.removeAttribute('dark-mode');
         }
-    });
-}
-
-// Refresh animations for visible sections
-function refreshAnimations() {
-    // Reset and retrigger animations for visible sections
-    document.querySelectorAll('.reveal.active').forEach(el => {
-        el.classList.remove('active');
-        setTimeout(() => {
-            el.classList.add('active');
-        }, 50);
-    });
-}
-
-// Initialize theme when DOM is loaded
-document.addEventListener('DOMContentLoaded', initTheme);
-
-// Add CSS for theme transition
-const style = document.createElement('style');
-style.textContent = `
-    .theme-transition,
-    .theme-transition * {
-        transition: background-color 0.5s ease, color 0.5s ease, border-color 0.5s ease, box-shadow 0.5s ease !important;
+        // Legacy class on the toggle button — kept for any older CSS that
+        // still keys off `.theme-toggle.dark`. Harmless if unused.
+        const themeToggle = document.querySelector('.theme-toggle');
+        if (themeToggle) themeToggle.classList.toggle('dark', theme === 'dark');
     }
-`;
-document.head.appendChild(style);
+
+    function setTheme(theme, persist) {
+        applyTheme(theme);
+        if (persist) {
+            try { localStorage.setItem(STORAGE_KEY, theme); } catch (_) {}
+        }
+    }
+
+    function resolveInitial() {
+        let stored = null;
+        try { stored = localStorage.getItem(STORAGE_KEY); } catch (_) {}
+        if (stored === 'dark' || stored === 'light') return stored;
+        return mqDark.matches ? 'dark' : 'light';
+    }
+
+    function initTheme() {
+        // The pre-paint script in <head> has already set one of the two
+        // attributes. Re-apply to make sure the toggle button class is
+        // in sync, then wire up the click handler.
+        const initial = resolveInitial();
+        applyTheme(initial);
+
+        const themeToggle = document.querySelector('.theme-toggle');
+        if (themeToggle) {
+            themeToggle.addEventListener('click', function () {
+                const isDark = ROOT.hasAttribute('dark-mode');
+                document.body.classList.add('theme-transition');
+                setTheme(isDark ? 'light' : 'dark', true);
+                setTimeout(() => document.body.classList.remove('theme-transition'), 500);
+                refreshAnimations();
+            });
+        }
+
+        // If the user hasn't set a manual preference, follow live system changes.
+        mqDark.addEventListener('change', function (e) {
+            let stored = null;
+            try { stored = localStorage.getItem(STORAGE_KEY); } catch (_) {}
+            if (stored === 'dark' || stored === 'light') return;
+            applyTheme(e.matches ? 'dark' : 'light');
+        });
+    }
+
+    function refreshAnimations() {
+        document.querySelectorAll('.reveal.active').forEach(el => {
+            el.classList.remove('active');
+            setTimeout(() => el.classList.add('active'), 50);
+        });
+    }
+
+    document.addEventListener('DOMContentLoaded', initTheme);
+
+    // Smooth color transition while a theme flip is in flight.
+    const style = document.createElement('style');
+    style.textContent = `
+        .theme-transition,
+        .theme-transition * {
+            transition: background-color 0.5s ease, color 0.5s ease,
+                        border-color 0.5s ease, box-shadow 0.5s ease !important;
+        }
+    `;
+    document.head.appendChild(style);
+})();


### PR DESCRIPTION
## Symptom

Mobile users reported the theme toggle button "doesn't switch" between
light and dark. Desktop worked.

## Root cause

The DS bundle uses a *two-attribute* model for theme override
(see `dzarlax.css` around line 1669):

```css
[dark-mode] .theme-toggle::after { /* slid dark */ }

@media (prefers-color-scheme: dark) {
    :root:not([light-mode]) .theme-toggle::after { /* slid dark */ }
}
```

Our `theme.js` only managed `[dark-mode]`. When a reader on a device
with **system pref = dark** clicked "switch to light", the JS removed
`[dark-mode]` and stored `theme=light`, but never set `[light-mode]`.
The fallback media query then matched (`:root:not([light-mode])` is
true when no `[light-mode]` is set, and `prefers-color-scheme: dark`
is true) and re-applied dark via the media query path.

Net: lander content went light (its CSS only listens to `[dark-mode]`)
but the toggle thumb and other DS-styled controls stayed in the dark
position. Looked exactly like "theme didn't switch".

Desktop usually runs system pref = light, so removing `[dark-mode]`
correctly resolved to light without needing `[light-mode]`. That's why
the bug was mobile-only in practice.

Also found: the blog's pre-paint script in `hugo/layouts/partials/head.html`
was writing `[data-theme="dark"]`, an attribute no CSS reads.

## Fix

Switch to the canonical two-attribute pattern the DS docstring
prescribes: at all times one of `[dark-mode]` or `[light-mode]` is set
on `<html>`. The runtime JS (`web/theme.js` and the synced
`hugo/assets/js/theme.js`) and both pre-paint scripts (lander
`index.html` and blog `head.html`) now agree on the same convention.

## Files

- `web/theme.js` — lander runtime
- `hugo/assets/js/theme.js` — blog runtime (kept in sync)
- `index.html` — lander pre-paint
- `hugo/layouts/partials/head.html` — blog pre-paint (also drops the
  dead `[data-theme]` write)

## Test plan

- [x] DevTools simulate `prefers-color-scheme: dark`. Load `/`. Toggle.
      `<html>` flips between `dark-mode` and `light-mode`. Bg + toggle
      thumb track each other.
- [x] DevTools simulate `prefers-color-scheme: light`. Same.
- [x] Load blog article. Same.
- [x] Reload after picking a theme — choice persists.
- [x] No-JS / `localStorage` disabled — pre-paint still resolves to one
      attribute (try/catch around `localStorage`).
